### PR TITLE
Fix nested links on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,10 +6,9 @@ export default function Home() {
     <>
       <Link href="/listings/new" className="text-blue-600 hover:underline">
         + New Listing
+      </Link>
       <Link href="/listings" className="ml-4 text-blue-600 hover:underline">
-  View Listings
-</Link>
-
+        View Listings
       </Link>
       <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">


### PR DESCRIPTION
## Summary
- Replace nested listing links with separate siblings on the home page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` font)*

------
https://chatgpt.com/codex/tasks/task_e_68961a1be62883269c50871532116fc7