### PR TITLE
Add responsive landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^6.13.0",
+        "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.536.0",
@@ -1841,6 +1842,39 @@
         "@prisma/debug": "6.13.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2282,7 +2316,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3968,7 +4002,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.13.0",
+    "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.536.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,112 +1,19 @@
-import Image from "next/image";
-import Link from "next/link";
+import { Hero } from "@/components/landing/hero";
+import { SearchBar } from "@/components/landing/search-bar";
+import { FeaturedListings } from "@/components/landing/featured-listings";
+import { Features } from "@/components/landing/features";
+import { CallToAction } from "@/components/landing/call-to-action";
+import { Footer } from "@/components/landing/footer";
 
 export default function Home() {
   return (
-<>
-  <Link href="/listings/new" className="text-blue-600 hover:underline">
-    + New Listing
-  </Link>
-  <Link href="/listings" className="ml-4 text-blue-600 hover:underline">
-    View Listings
-  </Link>
-  <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-    <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-      <Image
-        className="dark:invert"
-        src="/next.svg"
-        alt="Next.js logo"
-        width={180}
-        height={38}
-        priority
-      />
-      <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-        <li className="mb-2 tracking-[-.01em]">
-          Get started by editing{" "}
-          <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-            src/app/page.tsx
-          </code>
-          .
-        </li>
-        <li className="tracking-[-.01em]">
-          Save and see your changes instantly.
-        </li>
-      </ol>
-
-      <div className="flex gap-4 items-center flex-col sm:flex-row">
-        <a
-          className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-          href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            className="dark:invert"
-            src="/vercel.svg"
-            alt="Vercel logomark"
-            width={20}
-            height={20}
-          />
-          Deploy now
-        </a>
-        <a
-          className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-          href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Read our docs
-        </a>
-      </div>
+    <main className="flex flex-col">
+      <Hero />
+      <SearchBar />
+      <FeaturedListings />
+      <Features />
+      <CallToAction />
+      <Footer />
     </main>
-    <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-      <a
-        className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-        href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <Image
-          aria-hidden
-          src="/file.svg"
-          alt="File icon"
-          width={16}
-          height={16}
-        />
-        Learn
-      </a>
-      <a
-        className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-        href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <Image
-          aria-hidden
-          src="/window.svg"
-          alt="Window icon"
-          width={16}
-          height={16}
-        />
-        Examples
-      </a>
-      <a
-        className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-        href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <Image
-          aria-hidden
-          src="/globe.svg"
-          alt="Globe icon"
-          width={16}
-          height={16}
-        />
-        Go to nextjs.org →
-      </a>
-    </footer>
-  </div>
-</>
   );
 }

--- a/src/components/landing/call-to-action.tsx
+++ b/src/components/landing/call-to-action.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export function CallToAction() {
+  return (
+    <section className="py-16 bg-blue-50 text-center">
+      <h2 className="text-3xl font-bold mb-4">Have a property to share?</h2>
+      <p className="mb-6 text-muted-foreground">
+        Join StayWise and reach thousands of travelers.
+      </p>
+      <Button asChild>
+        <Link href="/listings/new">Become a Host</Link>
+      </Button>
+    </section>
+  );
+}

--- a/src/components/landing/featured-listings.tsx
+++ b/src/components/landing/featured-listings.tsx
@@ -1,0 +1,58 @@
+import Image from "next/image";
+import { Card, CardContent } from "@/components/ui/card";
+
+const listings = [
+  {
+    id: 1,
+    title: "Cozy Cabin Retreat",
+    location: "Lakeview, OR",
+    price: 120,
+    image: "/images/listing1.jpg",
+  },
+  {
+    id: 2,
+    title: "Beachfront Bungalow",
+    location: "Maui, HI",
+    price: 220,
+    image: "/images/listing2.jpg",
+  },
+  {
+    id: 3,
+    title: "Urban Loft",
+    location: "Austin, TX",
+    price: 150,
+    image: "/images/listing3.jpg",
+  },
+];
+
+export function FeaturedListings() {
+  return (
+    <section className="max-w-6xl mx-auto py-16 px-4">
+      <h2 className="text-3xl font-bold mb-8 text-center">
+        Featured Listings
+      </h2>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {listings.map((listing) => (
+          <Card key={listing.id} className="overflow-hidden">
+            <Image
+              src={listing.image}
+              alt={listing.title}
+              width={400}
+              height={300}
+              className="h-48 w-full object-cover"
+            />
+            <CardContent className="p-4">
+              <h3 className="text-xl font-semibold">{listing.title}</h3>
+              <p className="text-sm text-muted-foreground">
+                {listing.location}
+              </p>
+              <p className="mt-2 font-bold">${listing.price} / night</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export { listings };

--- a/src/components/landing/features.tsx
+++ b/src/components/landing/features.tsx
@@ -1,0 +1,50 @@
+import { ShieldCheck, Lock, MapPin } from "lucide-react";
+
+const features = [
+  {
+    icon: ShieldCheck,
+    title: "Verified Hosts",
+    description: "Every host is vetted for quality and reliability.",
+  },
+  {
+    icon: Lock,
+    title: "Secure Booking",
+    description: "Your payment information is safe with SSL encryption.",
+  },
+  {
+    icon: MapPin,
+    title: "Beautiful Locations",
+    description: "Stay in stunning destinations around the globe.",
+  },
+];
+
+export function Features() {
+  return (
+    <section className="bg-orange-50 py-16">
+      <div className="max-w-6xl mx-auto px-4">
+        <h2 className="text-3xl font-bold text-center mb-8">
+          Why StayWise?
+        </h2>
+        <div className="grid gap-8 sm:grid-cols-3">
+          {features.map((feature) => (
+            <div
+              key={feature.title}
+              className="text-center flex flex-col items-center"
+            >
+              <feature.icon
+                className="h-12 w-12 text-orange-500 mb-4"
+                aria-hidden="true"
+              />
+              <h3 className="text-xl font-semibold mb-2">
+                {feature.title}
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                {feature.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+export function Footer() {
+  return (
+    <footer className="bg-muted py-8">
+      <div className="max-w-6xl mx-auto px-4 flex flex-col md:flex-row items-center justify-between gap-4 text-sm">
+        <span>&copy; {new Date().getFullYear()} StayWise</span>
+        <nav className="flex gap-4">
+          <Link href="#" className="hover:underline">
+            About
+          </Link>
+          <Link href="#" className="hover:underline">
+            Contact
+          </Link>
+          <Link href="#" className="hover:underline">
+            Privacy Policy
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -1,0 +1,25 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export function Hero() {
+  return (
+    <section className="relative h-[80vh] flex items-center justify-center text-center">
+      <Image
+        src="/images/hero.jpg"
+        alt="Tropical beach with palm trees"
+        fill
+        priority
+        className="object-cover"
+      />
+      <div className="relative z-10 bg-black/40 p-6 rounded-lg text-white max-w-xl mx-auto">
+        <h1 className="text-4xl md:text-5xl font-bold mb-4">
+          Discover Your Next Getaway
+        </h1>
+        <Button asChild>
+          <Link href="#search">Start Exploring</Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/search-bar.tsx
+++ b/src/components/landing/search-bar.tsx
@@ -1,0 +1,25 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function SearchBar() {
+  return (
+    <section
+      id="search"
+      className="max-w-4xl mx-auto -mt-16 relative z-20 p-4"
+    >
+      <form className="bg-white/90 backdrop-blur rounded-lg shadow-md p-4 grid grid-cols-1 md:grid-cols-5 gap-4">
+        <Input
+          placeholder="Destination"
+          aria-label="Destination"
+          className="md:col-span-2"
+        />
+        <Input type="date" aria-label="Check-in" />
+        <Input type="date" aria-label="Check-out" />
+        <Input type="number" min={1} aria-label="Guests" placeholder="Guests" />
+        <Button className="md:col-span-5 w-full" type="button">
+          Search
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-orange-500 text-white hover:bg-orange-600",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "underline-offset-4 hover:underline text-primary",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = "text", ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };


### PR DESCRIPTION
## Summary
- Replace default home page with a responsive landing layout and shadcn-styled components
- Add hero, search bar, featured listings with mock data, feature highlights, host CTA, and footer
- Introduce Button, Card, and Input shadcn UI primitives and Radix Slot dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any types and hook usage in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689a236e2c908326bb491a52691a9019