### PR TITLE
feat: unify branding and layout styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,4 @@
+/* Global styles: tweak typography scale and focus ring utilities here. */
 @import "tailwindcss";
 @import "tw-animate-css";
 
@@ -6,8 +7,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -117,6 +118,24 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-surface text-text font-sans leading-relaxed;
+  }
+  h1 {
+    @apply text-4xl font-bold tracking-tight;
+  }
+  h2 {
+    @apply text-3xl font-semibold tracking-tight;
+  }
+  h3 {
+    @apply text-2xl font-semibold tracking-tight;
+  }
+  p {
+    @apply leading-7;
+  }
+}
+
+@layer utilities {
+  .focus-ring {
+    @apply focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-600;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,17 @@
+// Layout: update font imports here to change site typography.
 import type { ReactNode } from "react";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "@/components/providers/Providers";
 import Header from "@/components/nav/Header";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-sans",
   subsets: ["latin"],
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+  variable: "--font-mono",
   subsets: ["latin"],
 });
 
@@ -22,7 +23,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${inter.variable} ${geistMono.variable} antialiased`}>
         <Providers>
           <Header />
           {children}

--- a/src/app/listings/[id]/BookingForm.tsx
+++ b/src/app/listings/[id]/BookingForm.tsx
@@ -1,9 +1,10 @@
-// src/app/listings/[id]/BookingForm.tsx
+// Booking form: uses shared Button for actions.
 "use client";
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession, signIn } from "next-auth/react";
+import { Button } from "@/components/ui/button";
 
 type Props = { listingId: string };
 
@@ -13,18 +14,15 @@ export default function BookingForm({ listingId }: Props) {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
 
   if (!session) {
     return (
-      <div className="p-4 border rounded bg-yellow-50">
+      <div className="p-4 border rounded bg-surface">
         <p className="mb-2">You must sign in to book.</p>
-        <button
-          type="button"
-          onClick={() => signIn()}
-          className="bg-blue-600 text-white px-4 py-2 rounded"
-        >
+        <Button type="button" onClick={() => signIn()}>
           Sign in
-        </button>
+        </Button>
       </div>
     );
   }
@@ -32,6 +30,7 @@ export default function BookingForm({ listingId }: Props) {
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+    setLoading(true);
     const res = await fetch("/api/bookings", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -43,11 +42,12 @@ export default function BookingForm({ listingId }: Props) {
     } else {
       router.push("/profile"); // or wherever you like
     }
+    setLoading(false);
   };
 
   return (
     <form onSubmit={submit} className="space-y-4 mt-6 max-w-md">
-      {error && <p role="alert" className="text-red-600">{error}</p>}
+      {error && <p role="alert" className="text-destructive-600">{error}</p>}
       <div>
         <label htmlFor="start" className="block mb-1">Start Date</label>
         <input
@@ -55,7 +55,7 @@ export default function BookingForm({ listingId }: Props) {
           type="date"
           value={startDate}
           onChange={(e) => setStartDate(e.target.value)}
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded focus-ring"
           required
         />
       </div>
@@ -66,16 +66,13 @@ export default function BookingForm({ listingId }: Props) {
           type="date"
           value={endDate}
           onChange={(e) => setEndDate(e.target.value)}
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded focus-ring"
           required
         />
       </div>
-      <button
-        type="submit"
-        className="w-full bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
-      >
+      <Button type="submit" className="w-full" disabled={loading} aria-busy={loading}>
         Book Now
-      </button>
+      </Button>
     </form>
   );
 }

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -1,9 +1,10 @@
-// src/app/listings/[id]/page.tsx
+// Listing detail page: uses container and unified Button.
 import prisma from "@/lib/prisma";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import ListingMap from "@/lib/Map";
 import BookingForm from "./BookingForm";
+import { Button } from "@/components/ui/button";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 
@@ -25,11 +26,11 @@ export default async function ListingPage({ params }: Params) {
 
   // 3. Render the listing details
   return (
-    <main className="max-w-3xl mx-auto p-4 space-y-4">
+    <main className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 space-y-4">
       <h1 className="text-3xl font-bold">{listing.title}</h1>
-      <p className="text-gray-700">{listing.description}</p>
+      <p className="text-text/80">{listing.description}</p>
       <div className="text-lg font-semibold">${listing.price.toFixed(2)}</div>
-      <div className="text-sm text-gray-500">{listing.location}</div>
+      <div className="text-sm text-text/60">{listing.location}</div>
       
       {/* Add the map component */}
       <div className="mt-6">
@@ -46,16 +47,18 @@ export default async function ListingPage({ params }: Params) {
         {session ? (
           <BookingForm listingId={listing.id} />
         ) : (
-          <div className="p-4 bg-yellow-50 border rounded">
+          <div className="p-4 border rounded bg-surface">
             <p className="mb-2">You must be signed in to make a booking.</p>
-            <Link href="/api/auth/signin" className="text-blue-600 underline">Sign in</Link>
+            <Button asChild variant="primary">
+              <Link href="/api/auth/signin">Sign in</Link>
+            </Button>
           </div>
         )}
       </section>
 
-      <Link href="/listings" className="text-blue-600 hover:underline block mt-8">
-        ← Back to all listings
-      </Link>
+      <Button asChild variant="ghost" className="mt-8">
+        <Link href="/listings">← Back to all listings</Link>
+      </Button>
     </main>
   );
 }

--- a/src/app/listings/new/page.tsx
+++ b/src/app/listings/new/page.tsx
@@ -1,8 +1,9 @@
-// src/app/listings/new/page.tsx
+// New listing form: uses container and shared Button component.
 "use client";
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
 
 export default function NewListingPage() {
   const router = useRouter();
@@ -13,6 +14,7 @@ export default function NewListingPage() {
     location: "",
   });
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -23,6 +25,7 @@ export default function NewListingPage() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
+    setLoading(true);
     try {
       const res = await fetch("/api/listings", {
         method: "POST",
@@ -41,14 +44,16 @@ export default function NewListingPage() {
       router.push("/");
     } catch (err: any) {
       setError(err.message);
+    } finally {
+      setLoading(false);
     }
   }
 
   return (
-    <main className="max-w-md mx-auto p-4">
+    <main className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <h1 className="text-2xl font-bold mb-4">Create New Listing</h1>
       {error && (
-        <p className="mb-4 text-red-600" role="alert">
+        <p className="mb-4 text-destructive-600" role="alert">
           {error}
         </p>
       )}
@@ -62,7 +67,7 @@ export default function NewListingPage() {
             name="title"
             value={form.title}
             onChange={handleChange}
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded focus-ring"
             required
           />
         </div>
@@ -75,7 +80,7 @@ export default function NewListingPage() {
             name="description"
             value={form.description}
             onChange={handleChange}
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded focus-ring"
             required
           />
         </div>
@@ -90,7 +95,7 @@ export default function NewListingPage() {
             step="0.01"
             value={form.price}
             onChange={handleChange}
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded focus-ring"
             required
           />
         </div>
@@ -103,16 +108,13 @@ export default function NewListingPage() {
             name="location"
             value={form.location}
             onChange={handleChange}
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded focus-ring"
             required
           />
         </div>
-        <button
-          type="submit"
-          className="w-full bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-        >
+        <Button type="submit" className="w-full" disabled={loading} aria-busy={loading}>
           Submit
-        </button>
+        </Button>
       </form>
     </main>
   );

--- a/src/app/listings/page.tsx
+++ b/src/app/listings/page.tsx
@@ -1,46 +1,51 @@
-// src/app/listings/page.tsx
+// Listings index: uses standard container and shared Button component.
 import Link from "next/link";
 import prisma from "@/lib/prisma";
 import ListingMap from "@/lib/Map";
+import { Button } from "@/components/ui/button";
 // Use the Prisma-generated Listing type for accurate typings
 import type { Listing } from "@prisma/client";
 
 
 export default async function ListingsPage() {
   // 1. Fetch all listings from the database
-  const listings = await prisma.listing.findMany({
+  const listings: Listing[] = await prisma.listing.findMany({
     orderBy: { createdAt: "desc" },
   });
 
   return (
-    <main className="max-w-4xl mx-auto px-4 py-6">
+    <main className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
       <h1 className="text-3xl font-bold mb-6">All Listings</h1>
       {listings.length === 0 ? (
-        <p>No listings yet. <Link href="/listings/new" className="text-blue-600 hover:underline">Create one?</Link></p>
+        <p>
+          No listings yet. {""}
+          <Button asChild variant="primary">
+            <Link href="/listings/new">Create one?</Link>
+          </Button>
+        </p>
       ) : (
         <ul className="space-y-4">
           {listings.map((listing) => (
             <div key={listing.id} className="border rounded-lg p-4 shadow-sm">
               <h2 className="text-xl font-semibold">{listing.title}</h2>
-              <p className="text-gray-700">{listing.description}</p>
-              <div className="text-lg font-semibold">${listing.price.toFixed(2)}</div>
-              <div className="text-sm text-gray-500 mb-4">{listing.location}</div>
-              
+              <p className="text-text/80">{listing.description}</p>
+              <div className="text-lg font-semibold">
+                ${listing.price.toFixed(2)}
+              </div>
+              <div className="text-sm text-text/60 mb-4">{listing.location}</div>
+
               {/* Add map for each listing */}
               <div className="mb-4">
-                <ListingMap 
-                  latitude={listing.latitude} 
+                <ListingMap
+                  latitude={listing.latitude}
                   longitude={listing.longitude}
                   zoom={12}
                 />
               </div>
-              
-              <Link
-                href={`/listings/${listing.id}`}
-                className="text-blue-600 hover:underline"
-              >
-                View Details
-              </Link>
+
+              <Button asChild variant="secondary">
+                <Link href={`/listings/${listing.id}`}>View Details</Link>
+              </Button>
             </div>
           ))}
         </ul>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+// Home page: wrapped in the standard container.
 import { Hero } from "@/components/landing/hero";
 import { SearchBar } from "@/components/landing/search-bar";
 import { FeaturedListings } from "@/components/landing/featured-listings";
@@ -7,10 +8,10 @@ import { Footer } from "@/components/landing/footer";
 
 export default function Home() {
   return (
-    <main className="flex flex-col">
+    <main className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex flex-col">
       <Hero />
       <SearchBar />
-  <FeaturedListings />
+      <FeaturedListings />
       <Features />
       <CallToAction />
       <Footer />

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,23 +1,21 @@
-// src/app/profile/page.tsx
+// Profile page: container and shared Button variants.
 import Link from "next/link";
 import Image from "next/image";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
 
 export default async function ProfilePage() {
   const session = await getServerSession(authOptions);
 
   if (!session) {
     return (
-      <main className="min-h-screen flex items-center justify-center">
+      <main className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 min-h-screen flex items-center justify-center">
         <div className="text-center">
           <h2 className="text-xl mb-4">You must sign in to view your profile.</h2>
-          <Link
-            href="/api/auth/signin"
-            className="bg-blue-600 text-white px-4 py-2 rounded"
-          >
-            Sign in
-          </Link>
+          <Button asChild variant="primary">
+            <Link href="/api/auth/signin">Sign in</Link>
+          </Button>
         </div>
       </main>
     );
@@ -25,7 +23,7 @@ export default async function ProfilePage() {
 
   const { user } = session;
   return (
-    <main className="min-h-screen flex flex-col items-center p-6 bg-gray-50">
+    <main className="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 min-h-screen flex flex-col items-center p-6 bg-surface">
       <h1 className="text-3xl font-bold mb-6">Your Profile</h1>
       {user.image && (
         <Image
@@ -44,12 +42,9 @@ export default async function ProfilePage() {
           <span className="font-semibold">Email:</span> {user.email}
         </p>
       </div>
-      <Link
-        href="/api/auth/signout"
-        className="mt-6 inline-block bg-red-600 text-white px-4 py-2 rounded"
-      >
-        Sign out
-      </Link>
+      <Button asChild variant="destructive" className="mt-6">
+        <Link href="/api/auth/signout">Sign out</Link>
+      </Button>
     </main>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,6 @@
+/* Button component: variants and focus styling using brand tokens. */
+"use client";
+
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -5,25 +8,25 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  "focus-ring inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 aria-[busy=true]:opacity-50 aria-[busy=true]:cursor-wait",
   {
     variants: {
       variant: {
-        default: "bg-orange-500 text-white hover:bg-orange-600",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "underline-offset-4 hover:underline text-primary",
+        primary: "bg-brand-600 text-white hover:bg-brand-700",
+        secondary: "bg-brand-100 text-brand-700 hover:bg-brand-200",
+        outline: "border border-brand-600 text-brand-600 hover:bg-brand-50",
+        ghost: "text-brand-600 hover:bg-brand-50",
+        destructive: "bg-destructive-600 text-white hover:bg-destructive-700",
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 px-3 rounded-md",
+        lg: "h-11 px-8 rounded-md",
         icon: "h-10 w-10",
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: "primary",
       size: "default",
     },
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+// Utility helper for merging Tailwind class names.
 import { ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,45 @@
+// Tailwind config: update brand colors and container settings here.
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/app/**/*.{ts,tsx}",
+    "./src/components/**/*.{ts,tsx}",
+    "./src/lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: {
+        DEFAULT: "1rem",
+        sm: "1.5rem",
+        lg: "2rem",
+      },
+      screens: {
+        "2xl": "1280px",
+      },
+    },
+    extend: {
+      colors: {
+        brand: {
+          50: "#eff6ff",
+          100: "#dbeafe",
+          200: "#bfdbfe",
+          300: "#93c5fd",
+          400: "#60a5fa",
+          500: "#3b82f6",
+          600: "#2563eb",
+          700: "#1d4ed8",
+          800: "#1e40af",
+          900: "#1e3a8a",
+        },
+        surface: "#ffffff",
+        text: "#0f172a",
+        destructive: {
+          600: "#dc2626",
+          700: "#b91c1c",
+        },
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add tailwind config with brand palette and container defaults
- load Inter font globally and standardize typography and focus styles
- create reusable Button component and apply brand containers across core pages

## Testing
- `npm run lint` *(fails: Unexpected any in existing API routes; React hook warning in Map.tsx)*
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689a4d68197c8326a410db28267b13fb